### PR TITLE
Added fixes from upstream material-ui nextjs examples

### DIFF
--- a/pages/_app.tsx
+++ b/pages/_app.tsx
@@ -13,6 +13,14 @@ class MyApp extends App {
     this.pageContext = getPageContext();
   }
 
+  componentDidMount() {
+    // Remove the server-side injected CSS.
+    const jssStyles = document.querySelector('#jss-server-side');
+    if (jssStyles && jssStyles.parentNode) {
+      jssStyles.parentNode.removeChild(jssStyles);
+    }
+  }
+
   render() {
     const { Component, pageProps } = this.props;
 

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -18,7 +18,7 @@ class MyDocument extends Document<Props> {
       return WrappedComponent;
     });
 
-    let css; // It might be undefined, e.g. after an error.
+    let css: string; // It might be undefined, e.g. after an error.
     if (pageContext) {
       css = pageContext.sheetsRegistry.toString();
     }

--- a/pages/_document.tsx
+++ b/pages/_document.tsx
@@ -18,12 +18,17 @@ class MyDocument extends Document<Props> {
       return WrappedComponent;
     });
 
+    let css; // It might be undefined, e.g. after an error.
+    if (pageContext) {
+      css = pageContext.sheetsRegistry.toString();
+    }
+
     return {
       ...page,
       pageContext,
       styles: (
         <React.Fragment>
-          <style id="jss-server-side" dangerouslySetInnerHTML={{ __html: pageContext.sheetsRegistry.toString() }} />
+          <style id="jss-server-side" dangerouslySetInnerHTML={{ __html: css }} />
           {flush() || null}
         </React.Fragment>
       )
@@ -32,13 +37,14 @@ class MyDocument extends Document<Props> {
 
   render() {
     const { pageContext } = this.props;
+    const themeColor = pageContext ? pageContext.theme.palette.primary.main : '';
 
     return (
       <html lang="en" dir="ltr">
         <Head>
           <meta charSet="utf-8" />
           <meta name="viewport" content={'user-scalable=0, initial-scale=1, minimum-scale=1, width=device-width, height=device-height'} />
-          <meta name="theme-color" content={pageContext.theme.palette.primary.main} />
+          <meta name="theme-color" content={themeColor} />
           <link rel="stylesheet" href="https://fonts.googleapis.com/css?family=Roboto:300,400,500" />
           <link rel="shortcut icon" type="image/x-icon" href="/static/favicon.ico" />
         </Head>


### PR DESCRIPTION
While working on the code, I encountered some strange errors which resulted in an undefined pageContext. The error was caused earlier on in middleware, but the undefined pageContext was crashing the server before the real error message could even get to the browser to be displayed. 

While searching for a solution, I found what I believe was the upstream for your _dashboard file, but with fixes for the errors I was encountering. I've also included more upstream code from _app that should probably be included, and deferred the themeColor in a similar way to the css.

upstream: 
  https://github.com/mui-org/material-ui/tree/master/examples/nextjs